### PR TITLE
#12 Adhere to debian conflict mgmt for config files; add new lint target

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This module holds the `clean` target to clean your workspace.
 ### package-debian.mk
 
 This module enables you to build a debian package from the local contents. The `package` target will compile the binary and create a .deb file which holds the contents in the `deb` folder and the binary.
-The module also enables you to build a debian package without compiling, using the `debian` target.
+The module also enables you to build a debian package *without compiling a binary*, using the `debian` target. This makes sense for example if the debian file should consist only of configuration files.
 
 Include only one of the files: package-debian.mk OR package-tar.mk
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,31 @@ This module holds the `clean` target to clean your workspace.
 
 This module enables you to build a debian package from the local contents. The `package` target will compile the binary and create a .deb file which holds the contents in the `deb` folder and the binary.
 The module also enables you to build a debian package *without compiling a binary*, using the `debian` target. This makes sense for example if the debian file should consist only of configuration files.
+The target `lint-deb-package` will show any errors or warnings for your built debian package.
 
 Include only one of the files: package-debian.mk OR package-tar.mk
+
+#### Package requirements
+
+You need a `deb` directory in order to successfully create a debian package. This directory is used to incorporate existing files and directories into the debian package. The minimum requirement for a valid debian package is a `control` file which you must place in `deb/DEBIAN/control`.
+
+As an extended example, a proper directory could look like this:
+
+```
+deb/
+ L DEBIAN/
+ |  L control
+ |  L postinst
+ L etc/ 
+    L config.file
+```
+
+Files which reside in `DEBIAN` will be subject to be stored in the `control` part of the debian package.
+In turn, all other files and directories will be stored in the `data` part of the debian package. 
+
+Please note when you are building a debian package that all files unter `/deb/etc` will be named in a automatically generated file `conffiles`. Those files will be subject to debian's conflict management instead of overwriting crucial configuration files when said configuration files already exist (f. i. when a package is upgraded).
+
+ 
 
 ### package-tar.mk
 

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -1,13 +1,13 @@
 PREPARE_PACKAGE?=prepare-package
+DEBIAN_PACKAGE_FORMAT_VERSION="2.0"
+CONFFILES_FILE="$(DEBIAN_CONTENT_DIR)/control/conffiles"
+CONFFILES_FILE_TMP="$(DEBIAN_CONTENT_DIR)/conffiles_"
 
 .PHONY: package
-package: debian-with-binary
+package: $(DEBIAN_PACKAGE)
 
 .PHONY: debian
 debian: $(DEBIAN_PACKAGE)
-
-.PHONY: debian-with-binary
-debian-with-binary: $(BINARY) $(DEBIAN_PACKAGE)
 
 .PHONY: prepare-package
 prepare-package:
@@ -17,32 +17,47 @@ $(DEBIAN_BUILD_DIR):
 	@mkdir $@
 
 $(DEBIAN_BUILD_DIR)/debian-binary: $(DEBIAN_BUILD_DIR)
-	@echo "2.0" > $@
+	@echo $(DEBIAN_PACKAGE_FORMAT_VERSION) > $@
 
-$(DEBIAN_PACKAGE): $(TARGET_DIR) $(DEBIAN_BUILD_DIR)/debian-binary ${PREPARE_PACKAGE} $(DEBSRC)
+$(DEBIAN_PACKAGE): $(BINARY) $(DEBIAN_BUILD_DIR)/debian-binary $(PREPARE_PACKAGE) $(DEBSRC)
 	@echo "Creating .deb package..."
 
+# populate control directory
 	@install -p -m 0755 -d $(DEBIAN_CONTENT_DIR)/control
 	@sed -e "s/^Version:.*/Version: $(VERSION)/g" deb/DEBIAN/control > $(DEBIAN_CONTENT_DIR)/_control
 	@install -p -m 0644 $(DEBIAN_CONTENT_DIR)/_control $(DEBIAN_CONTENT_DIR)/control/control
 
-# creating control.tar.gz
-	@tar cvfz $(DEBIAN_CONTENT_DIR)/control.tar.gz -C $(DEBIAN_CONTENT_DIR)/control $(TAR_ARGS) .
+# populate data directory
+	@for dir in $$(find deb -mindepth 1 -not -name "DEBIAN" -a -type d |sed s@"^deb/"@"$(DEBIAN_CONTENT_DIR)/data/"@) ; do \
+		install -m 0755 -d $${dir} ; \
+	done
 
-# populating data directory
-	@for dir in $$(find deb -mindepth 1 -not -name "DEBIAN" -a -type d |sed s@"^deb/"@"$(DEBIAN_CONTENT_DIR)/data/"@) ; do install -m 0755 -d $${dir} ; done
-	@for file in $$(find deb -mindepth 1 -type f | grep -v "DEBIAN") ; do install -m 0644 $${file} $(DEBIAN_CONTENT_DIR)/data/$${file#deb/}; done
+	@for file in $$(find deb -mindepth 1 -type f | grep -v "DEBIAN") ; do \
+		install -m 0644 $${file} $(DEBIAN_CONTENT_DIR)/data/$${file#deb/} ; \
+	done
 
-# Copy binary to /usr/sbin, if it exists
+# Copy binary to data/usr/sbin, if it exists
 	@if [ -f $(BINARY) ]; then \
-		echo "Copying binary to /usr/sbin"; \
+		echo "Copying binary to $(DEBIAN_CONTENT_DIR)/data/usr/sbin"; \
 		install -p -m 0755 -d $(DEBIAN_CONTENT_DIR)/data/usr/sbin; \
 		install -p -m 0755 $(BINARY) $(DEBIAN_CONTENT_DIR)/data/usr/sbin/; \
 	fi
 
-# creating data.tar.gz
+# create conffiles file which help to deal with config change
+# in order to successfully add the conffiles file to the archive it must exist, even empty
+	@touch $(CONFFILES_FILE_TMP)
+	@for file in $$(find $(DEBIAN_CONTENT_DIR)/data/etc -mindepth 1 -type f | grep -v "DEBIAN") ; do \
+		echo $$file | sed s@'.*\(/etc/\)@\1'@ >> $(CONFFILES_FILE_TMP) ; \
+	done
+	@install -p -m 0644 $(CONFFILES_FILE_TMP) $(CONFFILES_FILE)
+
+# create control.tar.gz
+	@tar cvfz $(DEBIAN_CONTENT_DIR)/control.tar.gz -C $(DEBIAN_CONTENT_DIR)/control $(TAR_ARGS) .
+
+# create data.tar.gz
 	@tar cvfz $(DEBIAN_CONTENT_DIR)/data.tar.gz -C $(DEBIAN_CONTENT_DIR)/data $(TAR_ARGS) .
-# creating package
+
+# create package
 	@ar roc $@ $(DEBIAN_BUILD_DIR)/debian-binary $(DEBIAN_CONTENT_DIR)/control.tar.gz $(DEBIAN_CONTENT_DIR)/data.tar.gz
 	@echo "... deb package can be found at $@"
 
@@ -95,3 +110,7 @@ remove-package-from-repo:
 
 .PHONY: undeploy
 undeploy: deploy-check remove-package-from-repo publish
+
+.PHONE: lint-deb-package
+lint-deb-package: debian
+	@lintian -i $(DEBIAN_PACKAGE)

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -4,10 +4,13 @@ CONFFILES_FILE="$(DEBIAN_CONTENT_DIR)/control/conffiles"
 CONFFILES_FILE_TMP="$(DEBIAN_CONTENT_DIR)/conffiles_"
 
 .PHONY: package
-package: $(DEBIAN_PACKAGE)
+package: debian-with-binary
 
 .PHONY: debian
 debian: $(DEBIAN_PACKAGE)
+
+.PHONY: debian-with-binary
+debian-with-binary: $(BINARY) $(DEBIAN_PACKAGE)
 
 .PHONY: prepare-package
 prepare-package:
@@ -19,7 +22,7 @@ $(DEBIAN_BUILD_DIR):
 $(DEBIAN_BUILD_DIR)/debian-binary: $(DEBIAN_BUILD_DIR)
 	@echo $(DEBIAN_PACKAGE_FORMAT_VERSION) > $@
 
-$(DEBIAN_PACKAGE): $(BINARY) $(DEBIAN_BUILD_DIR)/debian-binary $(PREPARE_PACKAGE) $(DEBSRC)
+$(DEBIAN_PACKAGE): $(TARGET_DIR) $(DEBIAN_BUILD_DIR)/debian-binary $(PREPARE_PACKAGE) $(DEBSRC)
 	@echo "Creating .deb package..."
 
 # populate control directory


### PR DESCRIPTION
During the upgrade of a Debian package configuration files may change
on both sides: the host, and the new package. This will lead to a
conflict which the package management tool is able to resolve in very
simple terms (f. i. no merge is possible).

The way how the `cesapp` Debian package is built does not support this
way of conflict solution. Instead, the package's configuration files
overwrite any changes made to the config files on the host.

This can lead to CES instances which will not be able to cope with non-
matching configurations up to that the CES instance will cease to
function properly.

This commit changes the build process by adding file that lists the
configuration files so that:

1. the Debian package management can recognize a set of given files as
config files
2. the Debian package management can try to resolve config file conflicts

It is necessary to change the order of build steps in the make target
`$(DEBIAN_PACKAGE)` so that the archives are created when all files
reside in the work directory.

Furthermore this adds a debian package lint target

Signed-off-by: Philipp Pixel <pixeloffice@philipppixel.de>