### PR TITLE
Make sure the TMP_DIR exists before updating makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ include build/make/bower.mk
 
 
 .PHONY: update-makefiles
-update-makefiles:
+update-makefiles: $(TMP_DIR)
 	@echo Updating makefiles...
 	@curl -L --silent https://github.com/cloudogu/makefiles/archive/v$(MAKEFILES_VERSION).tar.gz > $(TMP_DIR)/makefiles-v$(MAKEFILES_VERSION).tar.gz
 


### PR DESCRIPTION
This change ensures that the TMP_DIR exists before the `update-makefiles` target is executed.

Resolves #11 