### PR TITLE
Remove temporary conffiles file after usage

### DIFF
--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -58,6 +58,7 @@ $(DEBIAN_PACKAGE): $(TARGET_DIR) $(DEBIAN_CONTENT_DIR)/control $(DEBIAN_CONTENT_
 		echo $$file | sed s@'.*\(/etc/\)@\1'@ >> $(CONFFILES_FILE_TMP) ; \
 	done
 	@install -p -m 0644 $(CONFFILES_FILE_TMP) $(CONFFILES_FILE)
+	@rm $(CONFFILES_FILE_TMP)
 
 # create control.tar.gz
 	@tar cvfz $(DEBIAN_CONTENT_DIR)/control.tar.gz -C $(DEBIAN_CONTENT_DIR)/control $(TAR_ARGS) .


### PR DESCRIPTION
$(CONFFILES_FILE_TMP) is removed after usage so it is not filled with duplicates if the deb package is built again.

Resolves #20 