### PR TITLE
#31 support `go mod` dependency resolution and customizable go commands

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Added
+
+- Add Go modules support  (#31)
+   - Go module is activated by setting GO_ENVIRONMENT=GO111MODULE=on before including variables.mk
+   - When working with go modules `dependencies-gomod.mk` has to be included.
+
+### Fixed
+
+- Furthermore this commit fixes a weird unit-test behaviour when the go-junit tool is older than the tests.
+
+
 ## [v2.0.0](https://github.com/cloudogu/makefiles/releases/tag/v2.0.0)
 
 Please note: Breaking change ahead. 

--- a/build/make/build.mk
+++ b/build/make/build.mk
@@ -9,9 +9,15 @@ PRE_COMPILE?=
 .PHONY: compile
 compile: $(BINARY)
 
+compile-ci:
+	@echo "Compiling (CI)..."
+	make compile-generic
+
 compile-generic:
 	@echo "Compiling..."
-	@go build -a -tags netgo $(LDFLAGS) -installsuffix cgo -o $(BINARY)
+# here is go called without mod capabilities because of error "go: error loading module requirements"
+# see https://github.com/golang/go/issues/30868#issuecomment-474199640
+	@CGO_ENABLED=0 go build -a -tags netgo $(LDFLAGS) -installsuffix cgo -o $(BINARY)
 
 
 ifeq ($(ENVIRONMENT), ci)

--- a/build/make/dependencies-gomod.mk
+++ b/build/make/dependencies-gomod.mk
@@ -1,0 +1,6 @@
+.PHONY: dependencies
+dependencies: vendor
+
+vendor:
+	@echo "Installing dependencies using go modules..."
+	${GO_CALL} mod vendor

--- a/build/make/static-analysis.mk
+++ b/build/make/static-analysis.mk
@@ -19,7 +19,7 @@ static-analysis-local: $(STATIC_ANALYSIS_DIR)/static-analysis-cs.log $(STATIC_AN
 	@cat $< | $(GOPATH)/bin/reviewdog -f checkstyle -diff "git diff develop"
 
 $(LINT): 
-	@go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	@${GO_CALL} get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 $(STATIC_ANALYSIS_DIR)/static-analysis.log: $(LINT)
 	@mkdir -p $(STATIC_ANALYSIS_DIR)
@@ -33,4 +33,4 @@ $(STATIC_ANALYSIS_DIR)/static-analysis-cs.log: $(LINT)
 	@$(LINT) $(LINTFLAGS) run --out-format=checkstyle ./... > $@ | true
 
 $(GOPATH)/bin/reviewdog:
-	@go get -u github.com/haya14busa/reviewdog/cmd/reviewdog
+	@${GO_CALL} get -u github.com/haya14busa/reviewdog/cmd/reviewdog

--- a/build/make/test-common.mk
+++ b/build/make/test-common.mk
@@ -1,2 +1,5 @@
+# This is a phony target because otherwise the go-junit-report file may be older than the dependent integration-test.xml
+# which leads to a non-execution of the actual ${XUNIT_INTEGRATION_XML} target.
+.PHONY: ${GOPATH}/bin/go-junit-report
 ${GOPATH}/bin/go-junit-report:
-	@go get -u github.com/jstemmer/go-junit-report
+	@${GO_CALL} get -u github.com/jstemmer/go-junit-report

--- a/build/make/test-integration.mk
+++ b/build/make/test-integration.mk
@@ -32,7 +32,7 @@ ${XUNIT_INTEGRATION_XML}: ${GOPATH}/bin/go-junit-report
 	@echo 'mode: set' > ${INTEGRATION_TEST_REPORT}
 	@rm -f $(INTEGRATION_TEST_LOG) || true
 	@for PKG in $(PACKAGES_FOR_INTEGRATION_TEST) ; do \
-    go test -tags=${GO_BUILD_TAG_INTEGRATION_TEST} -v $$PKG -coverprofile=${INTEGRATION_TEST_REPORT}.tmp 2>&1 | tee $(INTEGRATION_TEST_LOG).tmp ; \
+    ${GO_CALL} test -tags=${GO_BUILD_TAG_INTEGRATION_TEST} -v $$PKG -coverprofile=${INTEGRATION_TEST_REPORT}.tmp 2>&1 | tee $(INTEGRATION_TEST_LOG).tmp ; \
 		cat ${INTEGRATION_TEST_REPORT}.tmp | tail +2 >> ${INTEGRATION_TEST_REPORT} ; \
 		rm -f ${INTEGRATION_TEST_REPORT}.tmp ; \
 		cat $(INTEGRATION_TEST_LOG).tmp >> $(INTEGRATION_TEST_LOG) ; \

--- a/build/make/test-unit.mk
+++ b/build/make/test-unit.mk
@@ -14,7 +14,7 @@ ${XUNIT_XML}: ${GOPATH}/bin/go-junit-report
 	@echo 'mode: set' > ${COVERAGE_REPORT}
 	@rm -f $(UNIT_TEST_LOG) || true
 	@for PKG in $(PACKAGES) ; do \
-    go test -v $$PKG -coverprofile=${COVERAGE_REPORT}.tmp 2>&1 | tee $(UNIT_TEST_LOG).tmp ; \
+    ${GO_CALL} test -v $$PKG -coverprofile=${COVERAGE_REPORT}.tmp 2>&1 | tee $(UNIT_TEST_LOG).tmp ; \
 		cat ${COVERAGE_REPORT}.tmp | tail +2 >> ${COVERAGE_REPORT} ; \
 		rm -f ${COVERAGE_REPORT}.tmp ; \
 		cat $(UNIT_TEST_LOG).tmp >> $(UNIT_TEST_LOG) ; \

--- a/build/make/variables.mk
+++ b/build/make/variables.mk
@@ -11,9 +11,12 @@ LAST_COMMIT_DATE=$(shell git rev-list --format=format:'%ci' --max-count=1 `git r
 TAR_ARGS:=--owner=0:0 --group=0:0 --mtime="$(LAST_COMMIT_DATE)" --sort=name
 BRANCH=$(shell git branch | grep \* | sed 's/ /\n/g' | head -2 | tail -1)
 
-PACKAGES=$(shell go list ./... | grep -v /vendor/)
-PACKAGES_FOR_INTEGRATION_TEST=${PACKAGES}
-GO_BUILD_TAG_INTEGRATION_TEST=integration
+GO_ENVIRONMENT?=
+# GO_CALL accomodates the go CLI command as well as necessary environment variables which are optional.
+GO_CALL=${GO_ENVIRONMENT} go
+PACKAGES=$(shell ${GO_CALL} list ./... | grep -v /vendor/)
+PACKAGES_FOR_INTEGRATION_TEST?=${PACKAGES}
+GO_BUILD_TAG_INTEGRATION_TEST?=integration
 
 SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "./vendor/*")
 


### PR DESCRIPTION
`Go mod` comes with some necessary environment variables. These may be vital for
running a whole project on `go mod` like tests, utility installation, building,
to just name a few. As not every project may want to set variables (not to speak
of using go modules) setting environment variables are purely optional.

Go module is activated by setting `GO_ENVIRONMENT=GO111MODULE=on` before
including `variables.mk`

Furthermore this commit fixes a weird unit-test behaviour when the go-junit tool
is older than the tests.