### PR TITLE
Go environment variable configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Please note: Default behaviour changed!
+The "CGO_ENABLED=0" variable is not set per default any more!
+You have to set it via the Makefile, if needed.
+
+### Added
+- Introduce GO_ENV_VARS for go environment variables
+
 ## [v3.0.1](https://github.com/cloudogu/makefiles/releases/tag/v3.0.1)
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ MAKEFILES_VERSION=3.0.0
 # set PRE_COMPILE to define steps that shall be executed before the go build
 # PRE_COMPILE=
 
+# set GO_ENV_VARS to define go environment variables for the go build
+# GO_ENV_VARS = CGO_ENABLED=0
+
 # set PRE_UNITTESTS and POST_UNITTESTS to define steps that shall be executed before or after the unit tests
 # PRE_UNITTESTS?=
 # POST_UNITTESTS?=

--- a/build/make/build.mk
+++ b/build/make/build.mk
@@ -5,6 +5,7 @@ GOTAG?=1.10.2-2
 GOOS?=linux
 GOARCH?=amd64
 PRE_COMPILE?=
+GO_ENV_VARS?=
 
 .PHONY: compile
 compile: $(BINARY)
@@ -17,7 +18,7 @@ compile-generic:
 	@echo "Compiling..."
 # here is go called without mod capabilities because of error "go: error loading module requirements"
 # see https://github.com/golang/go/issues/30868#issuecomment-474199640
-	@CGO_ENABLED=0 go build -a -tags netgo $(LDFLAGS) -installsuffix cgo -o $(BINARY)
+	@$(GO_ENV_VARS) go build -a -tags netgo $(LDFLAGS) -installsuffix cgo -o $(BINARY)
 
 
 ifeq ($(ENVIRONMENT), ci)


### PR DESCRIPTION
Make Go environment variables configurable via the main Makefile
Resolves #41 