### PR TITLE
Feature/47 allow extending debian packaging mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add custom target before packaging files into debian package (#47)
+   - own targets can be hooked by overwriting the variable `PRE_CREATE_PACKAGE=your-custom-target`
+   - this allows for a wide range of extension (f. i. coping with additional files that were not designed by the packaging mechanism)
+- Add separate phony clean target `clean-deb` for cleaning the debian build directory (#48)
+   - this target can be combined with the general `clean` target by overwriting the variable `ADDITIONAL_CLEAN=clean-deb`
+   
+### Changed
+- the debian packaging target `$(DEBIAN_PACKAGE)` was split (#47)
+   - This allows for more extensibility during the packaging and includes the new `${PRE_CREATE_PACKAGE}` target
+- change default permissions for files under `/usr/share/doc/`
+   - any files found under `/usr/share/doc/` receive now a file permission setting of `0644` according the Debian packaging rules 
 
 ## [v4.1.0](https://github.com/cloudogu/makefiles/releases/tag/v4.1.0) 2020-05-25
 ### Fixed

--- a/build/make/deploy-debian.mk
+++ b/build/make/deploy-debian.mk
@@ -3,6 +3,8 @@
 
 # Attention: This Makefile depends on package-debian.mk!
 
+APTLY:=curl --silent --show-error --fail -u "${APT_API_USERNAME}":"${APT_API_PASSWORD}"
+
 .PHONY: deploy-check
 deploy-check:
 	@case X"${VERSION}" in *-SNAPSHOT) echo "i will not upload a snaphot version for you" ; exit 1; esac;

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -25,6 +25,10 @@ prepare-package:
 pre-create-package:
 	@echo "Using default pre-create-package target. To write your own, define a target and specify it in the PRE_CREATE_PACKAGE variable, before the package-debian.mk import"
 
+.PHONY: clean-deb
+clean-deb:
+	rm -rf ${DEBIAN_BUILD_DIR}
+
 $(DEBIAN_BUILD_DIR):
 	@mkdir $@
 

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -94,4 +94,4 @@ set-permissions:
 	done
 	@for file in $$(find $(DEBIAN_CONTENT_DIR)/data/usr/share/doc -mindepth 1 -type f | grep -v "DEBIAN") ; do \
     	chmod 0644 $$file ; \
-    done
+	done

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -86,5 +86,3 @@ set-permissions:
 	@for file in $$(find $(DEBIAN_CONTENT_DIR)/data/etc -mindepth 1 -type f | grep -v "DEBIAN") ; do \
 		chmod 0644 $$file ; \
 	done
-
-APTLY:=curl --silent --show-error --fail -u "${APT_API_USERNAME}":"${APT_API_PASSWORD}"

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -82,7 +82,10 @@ debian-copy-files:
 
 .PHONY: set-permissions
 set-permissions:
-	@echo "Setting default permissions"
+	@echo "Setting default permissions..."
 	@for file in $$(find $(DEBIAN_CONTENT_DIR)/data/etc -mindepth 1 -type f | grep -v "DEBIAN") ; do \
 		chmod 0644 $$file ; \
 	done
+	@for file in $$(find $(DEBIAN_CONTENT_DIR)/data/usr/share/doc -mindepth 1 -type f | grep -v "DEBIAN") ; do \
+    	chmod 0644 $$file ; \
+    done

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -44,7 +44,7 @@ $(DEBIAN_PACKAGE): $(TARGET_DIR) $(DEBIAN_CONTENT_DIR)/control $(DEBIAN_CONTENT_
 # create data.tar.gz
 	@tar cvfz $(DEBIAN_CONTENT_DIR)/data.tar.gz -C $(DEBIAN_CONTENT_DIR)/data $(TAR_ARGS) .
 
-# create package
+# create final debian package
 	@ar roc $@ $(DEBIAN_BUILD_DIR)/debian-binary $(DEBIAN_CONTENT_DIR)/control.tar.gz $(DEBIAN_CONTENT_DIR)/data.tar.gz
 	@echo "... deb package can be found at $@"
 
@@ -60,6 +60,8 @@ debian-copy-files:
 		install -m 0755 -d $${dir} ; \
 	done
 
+# This is a shell loop, not a makefile loop, that's why bash variables need to be escaped with $$.
+# ${file#deb/} trims the prefix "deb/" from the file path. See https://tldp.org/LDP/abs/html/string-manipulation.html
 	@for file in $$(find deb -mindepth 1 -type f | grep -v "DEBIAN") ; do \
 		cp $${file} $(DEBIAN_CONTENT_DIR)/data/$${file#deb/} ; \
 	done

--- a/build/make/package-debian.mk
+++ b/build/make/package-debian.mk
@@ -93,5 +93,5 @@ set-permissions:
 		chmod 0644 $$file ; \
 	done
 	@for file in $$(find $(DEBIAN_CONTENT_DIR)/data/usr/share/doc -mindepth 1 -type f | grep -v "DEBIAN") ; do \
-    	chmod 0644 $$file ; \
+		chmod 0644 $$file ; \
 	done


### PR DESCRIPTION
This PR solves issue #47 and changes the way of creating Debian packages by
- splitting the packaging target into separate ones
- adding a new target before the actual packaging for additional customization

The downstream issue cloudogu/cesapp#307 to add more than one executable to the `.deb` package might be the primary reason for the additional target. Anyhow the new target is provided without semantics and can be used for many other things as well.

Additionally to the changed debian packaging, this PR solves #48 and adds a cleaning-target `clean-deb` which can be be used  to incorporate into the general cleaning routine if desired.

Resolve #47
Resolve #48