### PR TITLE
Call go mod vendor after retrieving the `go-junit-report` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Calls an additional `go mod vendor` after installing `j-unit-report` to prevent inconsistencies between `go.mod` and `vendor/modules.txt` [#53]. 
 
 ## [v4.3.0](https://github.com/cloudogu/makefiles/releases/tag/v4.3.0) 2020-12-17
 **Breaking Change ahead!**, see below

--- a/build/make/test-common.mk
+++ b/build/make/test-common.mk
@@ -1,2 +1,3 @@
 $(GOPATH)/bin/go-junit-report:
 	@$(GO_CALL) get -u github.com/jstemmer/go-junit-report
+	@go mod vendor


### PR DESCRIPTION
Resolves #53 