### PR TITLE
Make the nodejs version adjustable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make the nodejs version adjustable via NODE_VERSION variable; #64
 
 ## [v4.6.0](https://github.com/cloudogu/makefiles/releases/tag/v4.6.0) 2021-9-16
 ## Changed 

--- a/build/make/bower.mk
+++ b/build/make/bower.mk
@@ -19,7 +19,7 @@ $(BOWER_TARGET): $(BOWER_JSON) $(PASSWD) $(YARN_TARGET)
 	  -v $(PASSWD):/etc/passwd:ro \
 	  -v $(WORKDIR):$(WORKDIR) \
 	  -w $(WORKDIR) \
-	  node:8 \
+	  node:$(NODE_VERSION) \
 	  yarn run bower
 	@touch $@
 

--- a/build/make/variables.mk
+++ b/build/make/variables.mk
@@ -58,3 +58,5 @@ $(PASSWD): $(TMP_DIR)
 $(ETCGROUP): $(TMP_DIR)
 	@echo "root:x:0:" > $(ETCGROUP)
 	@echo "$(USER):x:$(GID_NR):" >> $(ETCGROUP)
+
+NODE_VERSION?=8

--- a/build/make/variables.mk
+++ b/build/make/variables.mk
@@ -36,6 +36,7 @@ endif
 
 YARN_TARGET=$(WORKDIR)/node_modules
 BOWER_TARGET?=$(WORKDIR)/public/vendor
+NODE_VERSION?=8
 
 UID_NR:=$(shell id -u)
 GID_NR:=$(shell id -g)
@@ -58,5 +59,3 @@ $(PASSWD): $(TMP_DIR)
 $(ETCGROUP): $(TMP_DIR)
 	@echo "root:x:0:" > $(ETCGROUP)
 	@echo "$(USER):x:$(GID_NR):" >> $(ETCGROUP)
-
-NODE_VERSION?=8

--- a/build/make/yarn.mk
+++ b/build/make/yarn.mk
@@ -18,7 +18,7 @@ $(YARN_TARGET): $(YARN_LOCK) $(PASSWD)
 	  -v $(PASSWD):/etc/passwd:ro \
 	  -v $(WORKDIR):$(WORKDIR) \
 	  -w $(WORKDIR) \
-	  node:8 \
+	  node:$(NODE_VERSION) \
 	  yarn install
 	@touch $@
 


### PR DESCRIPTION
- Make the nodejs version adjustable via NODE_VERSION variable
   - `node:8` remains as the default
- Resolves #64 