### PR TITLE
Use alphabetic characters class instead of a-Z range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make grep regex work with grep v3.7; #66
 
 ## [v4.7.0](https://github.com/cloudogu/makefiles/releases/tag/v4.7.0) 2021-11-30
 ### Changed

--- a/build/make/release_functions.sh
+++ b/build/make/release_functions.sh
@@ -22,7 +22,7 @@ ask_yes_or_no(){
 }
 
 get_current_version_by_makefile(){
-  grep '^VERSION=[0-9a-Z.-]*$' Makefile | sed s/VERSION=//g
+  grep '^VERSION=[0-9[:alpha:].-]*$' Makefile | sed s/VERSION=//g
 }
 
 get_current_version_by_dogu_json(){


### PR DESCRIPTION
Use the [:alpha:] characters class instead of the a-Z range, because the range does not work with grep v3.7 any more.

Resolves #66 