### PR TITLE
#68 Extend release shell scripts with extension points

### DIFF
--- a/build/make/release.sh
+++ b/build/make/release.sh
@@ -3,6 +3,33 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Extension points in release.sh:
+#
+# A custom release argument file will be sourced if found. The custom release arg file may implement one or more bash
+# functions which either release.sh or release_functions.sh define. If such a custom release function is found the
+# release script must define the argument list which the custom release function will receive during the release.
+
+sourceCustomReleaseArgs() {
+  RELEASE_ARGS_FILE="${1}"
+
+  if [[ -f "${RELEASE_ARGS_FILE}" ]]; then
+    echo "Using custom release args file ${RELEASE_ARGS_FILE}"
+
+    sourceCustomReleaseExitCode=0
+    # shellcheck disable=SC1090
+    source "${RELEASE_ARGS_FILE}" || sourceCustomReleaseExitCode=$?
+    if [[ ${sourceCustomReleaseExitCode} -ne 0 ]]; then
+      echo "Error while sourcing custom release arg file ${sourceCustomReleaseExitCode}. Exiting."
+      exit 9
+    fi
+  fi
+}
+
+PROJECT_DIR="$(pwd)"
+RELEASE_ARGS_FILE="${PROJECT_DIR}/release_args.sh"
+
+sourceCustomReleaseArgs "${RELEASE_ARGS_FILE}"
+
 source "$(pwd)/build/make/release_functions.sh"
 
 TYPE="${1}"


### PR DESCRIPTION
During the release process it might be necessary to modify version within files
that are not tracked by the makefiles (files like Dockerfile, pom.xml, Makefile,
and so on). It also makes sense to not extend these files in all eternity but
rather create true extensibility.

This commit adds this extensibility by having a fixed file in the project's
workspace: `release_args.sh`. This file may define shell functions which are
optionally called (if found) by `release_functions.sh`.