### PR TITLE
Use same temporary k8s yaml resource file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use consistent temporary yaml file names in k8s makefiles
+
 ## [v6.0.2](https://github.com/cloudogu/makefiles/releases/tag/v6.0.2) 2022-06-07
 ### Changed
 - Moved function `go-get-tool` from `dependencies-gomod.mk` to `variables.mk`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Use consistent temporary yaml file names in k8s makefiles
+- Use consistent temporary yaml file names in k8s makefiles: #86
 
 ## [v6.0.2](https://github.com/cloudogu/makefiles/releases/tag/v6.0.2) 2022-06-07
 ### Changed

--- a/build/make/k8s-controller.mk
+++ b/build/make/k8s-controller.mk
@@ -18,9 +18,6 @@ include $(WORKDIR)/build/make/k8s.mk
 
 ## Variables
 
-# Contains the artifact yaml used as
-K8S_RESOURCE_TEMP_YAML=${TARGET_DIR}/${ARTIFACT_ID}_${VERSION}.yaml
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/build/make/k8s-dogu.mk
+++ b/build/make/k8s-dogu.mk
@@ -41,8 +41,6 @@ K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 .PHONY: install-dogu-descriptor
 install-dogu-descriptor: $(TARGET_DIR) ## Installs a configmap with current dogu.json into the cluster.
 	@echo "Generate configmap from dogu.json..."
-
 	@jq ".Image=\"${IMAGE_DEV_WITHOUT_TAG}\"" ${DOGU_JSON_FILE} > ${DOGU_JSON_DEV_FILE}
-
 	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f -
 	@echo "Done."

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -20,7 +20,7 @@ K3CES_REGISTRY_URL_PREFIX="${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}"
 # Variables for the temporary yaml files. These are used as template to generate a development resource containing
 # the current namespace and the dev image.
 K8S_RESOURCE_TEMP_FOLDER ?= $(TARGET_DIR)/make/k8s
-K8S_RESOURCE_TEMP_YAML ?= $(K8S_RESOURCE_TEMP_FOLDER)/$(ARTIFACT_ID).yaml
+K8S_RESOURCE_TEMP_YAML ?= $(K8S_RESOURCE_TEMP_FOLDER)/$(ARTIFACT_ID)_$(VERSION).yaml
 
 # The current namespace is extracted from the current context.
 K8S_CURRENT_NAMESPACE=$(shell kubectl config view --minify -o jsonpath='{..namespace}')


### PR DESCRIPTION
K8s releases were temporary generated either in `target` for controllers or in `target/make/k8s` for other.
Use consistent `target/make/k8s` folder with `<artifact_id>_<version>.yaml` as file name.

Resolves #86 