### PR TITLE
Update target static-analysis.mk #94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Fixed golangci-lint and added new linters #94
 - Create folder `target/make/k8s` for target `k8s-create-temporary-resource` #93
+
+### Removed
+- Removed `vet` target because `vet` is used in golangci-lint #94
 
 ## [v6.3.0](https://github.com/cloudogu/makefiles/releases/tag/v6.3.0) 2022-08-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed `vet` target because `vet` is used in golangci-lint #94
+  - Projects must specify the path in `sonar-project.properties` to the golanci-lint report instead of the vet report:
+  `sonar.go.golangci-lint.reportPaths=target/static-analysis/static-analysis-cs.log`
 
 ## [v6.3.0](https://github.com/cloudogu/makefiles/releases/tag/v6.3.0) 2022-08-24
 ### Added


### PR DESCRIPTION
- Upgrade golanci-linter to 1.49.0
- Upgrade used go version to 1.18
- Use exit code 0 on linting issues to prevent pipeline failure
- Delete vet target because vet is used in golangci-lint

Resolves #94