### PR TITLE
Remove the env var K8S_CLUSTER_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#103] Remove the environment variable `K8S_CLUSTER_ROOT`, because it is no longer needed.
 
 ## [v7.1.1](https://github.com/cloudogu/makefiles/releases/tag/v7.1.1) 2022-11-30
 ### Fixed

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -8,8 +8,6 @@ endif
 
 BINARY_YQ = $(UTILITY_BIN_PATH)/yq
 
-# The cluster root variable is used to the build images to the cluster. It can be defined in a .myenv file.
-K8S_CLUSTER_ROOT ?=
 # The productive tag of the image
 IMAGE ?=
 
@@ -28,11 +26,7 @@ K8S_CURRENT_NAMESPACE=$(shell kubectl config view --minify -o jsonpath='{..names
 ##@ K8s - Variables
 
 .PHONY: check-all-vars
-check-all-vars: check-k8s-cluster-root-env-var check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry ## Conduct a sanity check against selected build artefacts or local environment
-
-.PHONY: check-k8s-cluster-root-env-var
-check-k8s-cluster-root-env-var:
-	@$(call check_defined, K8S_CLUSTER_ROOT, root path of your k3ces)
+check-all-vars: check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry ## Conduct a sanity check against selected build artefacts or local environment
 
 .PHONY: check-k8s-image-env-var
 check-k8s-image-env-var:


### PR DESCRIPTION
This var is no longer needed but was mandatory to set it because it was used in the check var target.

Resolves #103 