### PR TITLE
Remove helmify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+# Removed
+- [#127] Remove helmify and just copy the release resource in the helm chart because the helmify generation does not fit with our name prefixes and does not recognize some properties like `publishNotReadyAddresses` from the service spec.
 
 ## [v7.9.0](https://github.com/cloudogu/makefiles/releases/tag/v7.9.0) 2023-07-06
 ### Added

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -121,6 +121,7 @@ k8s-helm-reinstall: k8s-helm-delete k8s-helm-apply ## Uninstalls the current hel
 
 .PHONY: k8s-helm-generate-release
 k8s-helm-generate-release: $(K8S_PRE_GENERATE_TARGETS) k8s-helm-generate-chart ## Generates the final helm chart with release urls.
+	@sed -i "s/'{{ .Namespace }}'/'{{ .Release.Namespace }}'/" ${K8S_HELM_TARGET}/templates/$(ARTIFACT_ID)_$(VERSION).yaml
 
 .PHONY: k8s-helm-package-release
 k8s-helm-package-release: ${BINARY_HELM}  k8s-helm-generate-release $(K8S_POST_GENERATE_TARGETS) ## Generates and packages the helm chart with release urls.


### PR DESCRIPTION
Remove helmify and just copy the release resource in the helm chart because the helmify generation does not fit with our name prefixes and does not recognize some properties like `publishNotReadyAddresses` from the service spec.

Resolves #127