### PR TITLE
Upgrade controller_gen_version to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update CONTROLLER_GEN_VERSION to v0.14.0 to avoid panic during manifest-run when using go1.22 [#178]
 
 ## [v9.0.3](https://github.com/cloudogu/makefiles/releases/tag/v9.0.3) 2024-03-18
 ### Change

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -11,7 +11,7 @@ BINARY_YQ_4_VERSION?=v4.40.3
 BINARY_HELM = $(UTILITY_BIN_PATH)/helm
 BINARY_HELM_VERSION?=v3.13.0
 CONTROLLER_GEN = $(UTILITY_BIN_PATH)/controller-gen
-CONTROLLER_GEN_VERSION?=v0.13.0
+CONTROLLER_GEN_VERSION?=v0.14.0
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.


### PR DESCRIPTION
Using go1.22 leads to a panic because of nil pointer dereference. Version 0.14.0 fixed this problem

Resolve #178 