### PR TITLE
Bugfix/185 update golangci lint version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- update Go version to 1.22 (for `make compile` and `make static analysis`) [#186]
+- update Go linter to 1.58.2 [#185]
+
+### Fixed
+- Fix false positive during Go linting with Go version 1.22 [#186]
 
 ## [v9.0.4](https://github.com/cloudogu/makefiles/releases/tag/v9.0.4) 2024-04-19
 ### Fixed
@@ -13,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CONTROLLER_GEN_VERSION to v0.14.0 to avoid panic during manifest-run when using go1.22 [#178]
 
 ## [v9.0.3](https://github.com/cloudogu/makefiles/releases/tag/v9.0.3) 2024-03-18
-### Change
+### Changed
 - Pick up mockery version when the version was defined before including `mocks.mk`
   - it is no longer necessary to set the version variable `MOCKERY_VERSION` _after_ including `mocks.mk`. Instead the variable can be overwritten before the include.
 

--- a/build/make/build.mk
+++ b/build/make/build.mk
@@ -3,7 +3,7 @@
 ADDITIONAL_LDFLAGS?=-extldflags -static
 LDFLAGS?=-ldflags "$(ADDITIONAL_LDFLAGS) -X main.Version=$(VERSION) -X main.CommitID=$(COMMIT_ID)"
 GOIMAGE?=golang
-GOTAG?=1.14.13
+GOTAG?=1.22
 GOOS?=linux
 GOARCH?=amd64
 PRE_COMPILE?=

--- a/build/make/static-analysis.mk
+++ b/build/make/static-analysis.mk
@@ -2,7 +2,7 @@
 
 STATIC_ANALYSIS_DIR=$(TARGET_DIR)/static-analysis
 GOIMAGE?=golang
-GOTAG?=1.18
+GOTAG?=1.22
 CUSTOM_GO_MOUNT?=-v /tmp:/tmp
 
 REVIEW_DOG=$(TMP_DIR)/bin/reviewdog

--- a/build/make/static-analysis.mk
+++ b/build/make/static-analysis.mk
@@ -7,9 +7,9 @@ CUSTOM_GO_MOUNT?=-v /tmp:/tmp
 
 REVIEW_DOG=$(TMP_DIR)/bin/reviewdog
 LINT=$(TMP_DIR)/bin/golangci-lint
-LINT_VERSION?=v1.49.0
+LINT_VERSION?=v1.58.2
 # ignore tests and mocks
-LINTFLAGS=--tests=false --skip-files="^.*_mock.go$$" --skip-files="^.*/mock.*.go$$" --timeout 10m --issues-exit-code 0
+LINTFLAGS=--tests=false --exclude-files="^.*_mock.go$$" --exclude-files="^.*/mock.*.go$$" --timeout 10m --issues-exit-code 0
 ADDITIONAL_LINTER=-E bodyclose -E containedctx -E contextcheck -E decorder -E dupl -E errname -E forcetypeassert -E funlen -E unparam
 
 .PHONY: static-analysis


### PR DESCRIPTION
this PR resolves #185 by updating the linter version
this PR resolves #186 by bumping the go version in `build.mk` and `static-analysis.mk`