### PR TITLE
Add make target to scan for vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add make target to scan go repositories for vulnerabilities using [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
+- Add make target `govulncheck` to scan go repositories for vulnerabilities using [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
 
 ### Changed
 - `bats.mk`: 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v9.1.0](https://github.com/cloudogu/makefiles/releases/tag/v9.1.0) 2024-06-28
 ### Added
-- Add support for remote runtimes and container-registries for k8s-make-targets [#18]
+- Add support for remote runtimes and container-registries for k8s-make-targets [#188]
   - The make-targets for k8s like dogu-`build`, `helm-apply` or `component-apply` now support deploying to remote kubernetes-clusters
 
 ## [v9.0.5](https://github.com/cloudogu/makefiles/releases/tag/v9.0.5) 2024-05-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add make target to scan go repositories for vulnerabilities using [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
+
 ### Changed
 - `bats.mk`: 
   - Raise BATS image version to 1.11.0

--- a/build/make/vulnerability-scan.mk
+++ b/build/make/vulnerability-scan.mk
@@ -1,0 +1,13 @@
+##@ Vulnerability scan
+
+GOVULNCHECK_BIN=${UTILITY_BIN_PATH}/govulncheck
+GOVULNCHECK_VERSION?=latest
+
+${GOVULNCHECK_BIN}: ${UTILITY_BIN_PATH}
+	$(call go-get-tool,$(GOVULNCHECK_BIN),golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION))
+
+.PHONY: govulncheck
+govulncheck: ${GOVULNCHECK_BIN} ## This target is used to scan the go repository against known vulnerabilities
+	@echo "Start vulnerability against repository"
+	${GOVULNCHECK_BIN} -show verbose ./...
+	@echo "Finished scan"


### PR DESCRIPTION
This PR adds the feature to scan vulnerabilities in go repositories using govulncheck. In contrast to trivy, govulncheck checks whether the vulnerability is used in the code.

For more information check: 
https://go.dev/doc/tutorial/govulncheck