### PR TITLE
Add missing yq dependency on docker-build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add missing yq dependency on docker-build target
 
 ## [v9.2.0](https://github.com/cloudogu/makefiles/releases/tag/v9.2.0) 2024-08-28
 ### Added

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -138,7 +138,7 @@ ${K8S_RESOURCE_TEMP_FOLDER}:
 ##@ K8s - Docker
 
 .PHONY: docker-build
-docker-build: check-docker-credentials check-k8s-image-env-var ## Builds the docker image of the K8s app.
+docker-build: check-docker-credentials check-k8s-image-env-var ${BINARY_YQ} ## Builds the docker image of the K8s app.
 	@echo "Building docker image $(IMAGE)..."
 	@DOCKER_BUILDKIT=1 docker build . -t $(IMAGE)
 


### PR DESCRIPTION
The docker-build target depends on the BINARY_YQ target, because inside it the IMAGE variable is used. In the moment this variable is used, it is evaluated and the evaluation depends on the yq binary.