### PR TITLE
change unittest-report generation from xml to json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- change unittest-report generation from xml to json to generate valid report files for jenkins [#194]
 
 ## [v9.2.1](https://github.com/cloudogu/makefiles/releases/tag/v9.2.1) 2024-09-05
 ### Fixed

--- a/build/make/test-common.mk
+++ b/build/make/test-common.mk
@@ -1,6 +1,6 @@
 GO_JUNIT_REPORT=$(UTILITY_BIN_PATH)/go-junit-report
-GO_JUNIT_REPORT_VERSION=v1.0.0
+GO_JUNIT_REPORT_VERSION=v2.1.0
 
 $(GO_JUNIT_REPORT): $(UTILITY_BIN_PATH)
 	@echo "Download go-junit-report..."
-	@$(call go-get-tool,$@,github.com/jstemmer/go-junit-report@$(GO_JUNIT_REPORT_VERSION))
+	@$(call go-get-tool,$@,github.com/jstemmer/go-junit-report/v2@$(GO_JUNIT_REPORT_VERSION))

--- a/build/make/test-unit.mk
+++ b/build/make/test-unit.mk
@@ -1,7 +1,7 @@
 ##@ Unit testing
 
 UNIT_TEST_DIR=$(TARGET_DIR)/unit-tests
-XUNIT_XML=$(UNIT_TEST_DIR)/unit-tests.xml
+XUNIT_JSON=$(UNIT_TEST_DIR)/report.json
 UNIT_TEST_LOG=$(UNIT_TEST_DIR)/unit-tests.log
 COVERAGE_REPORT=$(UNIT_TEST_DIR)/coverage.out
 
@@ -9,9 +9,9 @@ PRE_UNITTESTS?=
 POST_UNITTESTS?=
 
 .PHONY: unit-test
-unit-test: $(XUNIT_XML) ## Start unit tests
+unit-test: $(XUNIT_JSON) ## Start unit tests
 
-$(XUNIT_XML): $(SRC) $(GO_JUNIT_REPORT)
+$(XUNIT_JSON): $(SRC) $(GO_JUNIT_REPORT)
 ifneq ($(strip $(PRE_UNITTESTS)),)
 	@make $(PRE_UNITTESTS)
 endif
@@ -20,13 +20,13 @@ endif
 	@echo 'mode: set' > ${COVERAGE_REPORT}
 	@rm -f $(UNIT_TEST_LOG) || true
 	@for PKG in $(PACKAGES) ; do \
-    ${GO_CALL} test -v $$PKG -coverprofile=${COVERAGE_REPORT}.tmp 2>&1 | tee $(UNIT_TEST_LOG).tmp ; \
+    ${GO_CALL} test -v $$PKG -coverprofile=${COVERAGE_REPORT}.tmp -json 2>&1 | tee $(UNIT_TEST_LOG).tmp ; \
 		cat ${COVERAGE_REPORT}.tmp | tail +2 >> ${COVERAGE_REPORT} ; \
 		rm -f ${COVERAGE_REPORT}.tmp ; \
 		cat $(UNIT_TEST_LOG).tmp >> $(UNIT_TEST_LOG) ; \
 		rm -f $(UNIT_TEST_LOG).tmp ; \
 	done
-	@cat $(UNIT_TEST_LOG) | $(GO_JUNIT_REPORT) > $@
+	@cat $(UNIT_TEST_LOG) >> $@
 	@if grep '^FAIL' $(UNIT_TEST_LOG); then \
 		exit 1; \
 	fi

--- a/build/make/test-unit.mk
+++ b/build/make/test-unit.mk
@@ -2,6 +2,7 @@
 
 UNIT_TEST_DIR=$(TARGET_DIR)/unit-tests
 XUNIT_JSON=$(UNIT_TEST_DIR)/report.json
+XUNIT_XML=$(UNIT_TEST_DIR)/unit-tests.xml
 UNIT_TEST_LOG=$(UNIT_TEST_DIR)/unit-tests.log
 COVERAGE_REPORT=$(UNIT_TEST_DIR)/coverage.out
 
@@ -27,6 +28,8 @@ endif
 		rm -f $(UNIT_TEST_LOG).tmp ; \
 	done
 	@cat $(UNIT_TEST_LOG) >> $@
+	@cat $(UNIT_TEST_LOG) | $(GO_JUNIT_REPORT) -parser gojson > $(XUNIT_XML)
+
 	@if grep '^FAIL' $(UNIT_TEST_LOG); then \
 		exit 1; \
 	fi


### PR DESCRIPTION
Use json as output format for "go test -json ..."

The result file needs to be referenced in dependent projects as:

`sonar.go.tests.reportPaths=target/unit-tests/report.json`