### PR TITLE
#214 removed double-quotes from variable-declaration in k8s.mk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- [#214] removed double-quotes from variable-declaration in k8s.mk
+
 ## [v9.5.2](https://github.com/cloudogu/makefiles/releases/tag/v9.5.2) 2024-01-15
 ### Added
  - [#201] prerelease make step for testing on stageing tests

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -36,11 +36,11 @@ K3S_LOCAL_REGISTRY_PORT?=30099
 
 # The URL of the container-registry to use. Defaults to the registry of the local-cluster.
 # If RUNTIME_ENV is "remote" it is "registry.cloudogu.com/testing"
-CES_REGISTRY_HOST?="${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}"
+CES_REGISTRY_HOST?=${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}
 CES_REGISTRY_NAMESPACE ?=
 ifeq (${RUNTIME_ENV}, remote)
-	CES_REGISTRY_HOST="registry.cloudogu.com"
-	CES_REGISTRY_NAMESPACE="/testing"
+	CES_REGISTRY_HOST=registry.cloudogu.com
+	CES_REGISTRY_NAMESPACE=/testing
 endif
 $(info CES_REGISTRY_HOST=$(CES_REGISTRY_HOST))
 


### PR DESCRIPTION
Some variables were declared with double-quotes like CES_REGISTRY_HOST="registry.cloudogu.com". The string value of the variable is then "registry.cloudogu.com" (including the double-quotes) which lead to errors in sed , yq and other tools


closes #214 