### PR TITLE
allow "component-apply" and "crd-component-apply" in development-stage on remote-environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#233] Allow "component-apply" and "crd-component-apply" in development-stage on remote-environments.
+- [#233] In development-stage add a timestamp as buildnumber to helm-chart-version to force helm to use the updated chart.
 
 ## [v10.1.1] - 2025-06-05
 ### Fixed

--- a/build/make/k8s-component.mk
+++ b/build/make/k8s-component.mk
@@ -1,4 +1,5 @@
-COMPONENT_DEV_VERSION?=${VERSION}-dev
+COMPONENT_BUILD_VERSION := $(shell date +%s)
+COMPONENT_DEV_VERSION?=${VERSION}-dev.${COMPONENT_BUILD_VERSION}
 
 include ${BUILD_DIR}/make/k8s.mk
 
@@ -15,8 +16,9 @@ HELM_RELEASE_TGZ=${HELM_TARGET_DIR}/${ARTIFACT_ID}-${VERSION}.tgz
 HELM_DEV_RELEASE_TGZ=${HELM_TARGET_DIR}/${ARTIFACT_ID}-${COMPONENT_DEV_VERSION}.tgz
 HELM_ARTIFACT_NAMESPACE?=k8s
 ifeq (${RUNTIME_ENV}, remote)
-	HELM_ARTIFACT_NAMESPACE?=testing/k8s
+	HELM_ARTIFACT_NAMESPACE=testing/k8s
 endif
+$(info HELM_ARTIFACT_NAMESPACE=$(HELM_ARTIFACT_NAMESPACE))
 
 K8S_RESOURCE_COMPONENT ?= "${K8S_RESOURCE_TEMP_FOLDER}/component-${ARTIFACT_ID}-${VERSION}.yaml"
 K8S_RESOURCE_COMPONENT_CR_TEMPLATE_YAML ?= $(BUILD_DIR)/make/k8s-component.tpl
@@ -93,10 +95,10 @@ helm-reinstall: helm-delete helm-apply ## Uninstalls the current helm chart and 
 .PHONY: helm-chart-import
 helm-chart-import: ${CHECK_VAR_TARGETS} helm-generate helm-package ${IMAGE_IMPORT_TARGET} ## Imports the currently available chart into the cluster-local registry.
 	@if [[ ${STAGE} == "development" ]]; then \
-		echo "Import ${HELM_DEV_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}..."; \
+		echo "Import ${HELM_DEV_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE}..."; \
 		${BINARY_HELM} push ${HELM_DEV_RELEASE_TGZ} oci://${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE} ${BINARY_HELM_ADDITIONAL_PUSH_ARGS}; \
 	else \
-	  	echo "Import ${HELM_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}..."; \
+	  	echo "Import ${HELM_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE}..."; \
         ${BINARY_HELM} push ${HELM_RELEASE_TGZ} oci://${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE} ${BINARY_HELM_ADDITIONAL_PUSH_ARGS}; \
     fi
 	@echo "Done."
@@ -142,7 +144,7 @@ ${K8S_RESOURCE_COMPONENT_CR_TEMPLATE_YAML}: ${K8S_RESOURCE_TEMP_FOLDER}
 	fi
 
 .PHONY: component-apply
-component-apply: isLocal check-k8s-namespace-env-var ${COMPONENT_PRE_APPLY_TARGETS} ${IMAGE_IMPORT_TARGET} helm-generate helm-chart-import component-generate ## Applies the component yaml resource to the actual defined context.
+component-apply: isProduction check-k8s-namespace-env-var ${COMPONENT_PRE_APPLY_TARGETS} ${IMAGE_IMPORT_TARGET} helm-generate helm-chart-import component-generate ## Applies the component yaml resource to the actual defined context.
 	@kubectl apply -f "${K8S_RESOURCE_COMPONENT}" --namespace="${NAMESPACE}" --context="${KUBE_CONTEXT_NAME}"
 	@echo "Done."
 

--- a/build/make/k8s-crd.mk
+++ b/build/make/k8s-crd.mk
@@ -5,7 +5,8 @@ ifeq ($(APPEND_CRD_SUFFIX), true)
 else ifeq ($(APPEND_CRD_SUFFIX), false)
 	ARTIFACT_CRD_ID = $(ARTIFACT_ID)
 endif
-DEV_CRD_VERSION ?= ${VERSION}-dev
+CRD_BUILD_VERSION := $(shell date +%s).$(TIMESTAMP)
+DEV_CRD_VERSION ?= ${VERSION}-dev.${COMPONENT_BUILD_VERSION}
 HELM_CRD_SOURCE_DIR ?= ${WORKDIR}/k8s/helm-crd
 HELM_CRD_TARGET_DIR ?= $(K8S_RESOURCE_TEMP_FOLDER)/helm-crd
 HELM_CRD_RELEASE_TGZ = ${HELM_CRD_TARGET_DIR}/${ARTIFACT_CRD_ID}-${VERSION}.tgz
@@ -89,10 +90,10 @@ ${HELM_CRD_RELEASE_TGZ}: ${BINARY_HELM} crd-helm-generate ## Generates and packa
 .PHONY: crd-helm-chart-import
 crd-helm-chart-import: ${CHECK_VAR_TARGETS} check-k8s-artifact-id crd-helm-generate crd-helm-package ## Imports the currently available Helm CRD chart into the cluster-local registry.
 	@if [[ ${STAGE} == "development" ]]; then \
-		echo "Import ${HELM_CRD_DEV_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}..."; \
+		echo "Import ${HELM_CRD_DEV_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE}..."; \
 		${BINARY_HELM} push ${HELM_CRD_DEV_RELEASE_TGZ} oci://${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE} ${BINARY_HELM_ADDITIONAL_PUSH_ARGS}; \
 	else \
-	  	echo "Import ${HELM_CRD_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}..."; \
+	  	echo "Import ${HELM_CRD_RELEASE_TGZ} into K8s cluster ${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE}..."; \
         ${BINARY_HELM} push ${HELM_CRD_RELEASE_TGZ} oci://${CES_REGISTRY_HOST}/${HELM_ARTIFACT_NAMESPACE} ${BINARY_HELM_ADDITIONAL_PUSH_ARGS}; \
     fi
 	@echo "Done."
@@ -111,7 +112,7 @@ crd-component-generate: ${K8S_RESOURCE_TEMP_FOLDER} ## Generate the CRD componen
 	fi
 
 .PHONY: crd-component-apply
-crd-component-apply: isLocal check-k8s-namespace-env-var crd-helm-chart-import crd-component-generate ## Applies the CRD component YAML resource to the actual defined context.
+crd-component-apply: isProduction check-k8s-namespace-env-var crd-helm-chart-import crd-component-generate ## Applies the CRD component YAML resource to the actual defined context.
 	@kubectl apply -f "${K8S_RESOURCE_CRD_COMPONENT}" --namespace="${NAMESPACE}" --context="${KUBE_CONTEXT_NAME}"
 	@echo "Done."
 

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -204,12 +204,13 @@ envtest: ${ENVTEST} ## Download envtest-setup locally if necessary.
 ${ENVTEST}:
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
-.PHONY: isLocal
-isLocal:
-	@if [[ ! ("${RUNTIME_ENV}" == "remote" || "${STAGE}" == "production") ]]; then \
-		echo "command executed locally, command continue execution."; \
+.PHONY: isProduction
+isProduction:
+	@if [[ "${STAGE}" == "production" ]]; then \
+		echo "Command executed in production stage. Aborting."; \
+		exit 1; \
 	else \
-		echo "command executed remotely or on production, command aborted"; exit 1; \
+		echo "Command executed in development stage. Continuing."; \
 	fi
 
 


### PR DESCRIPTION
in development-stage add a timestamp as buildnumber to helm-chart-version to force helm to use the updated chart

closes #233 