### PR TITLE
Bugfix/235 re-add local report file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#235] Updates BATS version to 1.12
+
+### Fixed
+- [#235] Fixes bug in which `make unit-test-shell` doesn't generate a xUnit report file. 
 
 ## [v10.2.0] - 2025-07-11
 ### Changed

--- a/build/make/bats.mk
+++ b/build/make/bats.mk
@@ -9,7 +9,7 @@ BATS_SUPPORT=$(BATS_LIBRARY_DIR)/bats-support
 BATS_FILE=$(BATS_LIBRARY_DIR)/bats-file
 BATS_BASE_IMAGE?=bats/bats
 BATS_CUSTOM_IMAGE?=cloudogu/bats
-BATS_TAG?=1.11.0
+BATS_TAG?=1.12.0
 BATS_DIR=build/make/bats
 BATS_WORKDIR="${WORKDIR}"/"${BATS_DIR}"
 

--- a/build/make/bats.mk
+++ b/build/make/bats.mk
@@ -56,7 +56,7 @@ unit-test-shell-generic:
 	@bats --report-formatter junit --formatter junit --output ${BASH_TEST_REPORT_DIR} ${TESTS_DIR}
 
 unit-test-shell-generic-no-junit:
-	@bats --report-formatter junit ${TESTS_DIR}
+	@bats --report-formatter junit --output ${BASH_TEST_REPORT_DIR} ${TESTS_DIR}
 
 .PHONY buildTestImage:
 buildTestImage:

--- a/build/make/bats.mk
+++ b/build/make/bats.mk
@@ -53,10 +53,10 @@ unit-test-shell-local: $(BASH_SRC) $(PASSWD) $(ETCGROUP) $(HOME_DIR) buildTestIm
 		"${BATS_DIR}"/customBatsEntrypoint.sh make unit-test-shell-generic-no-junit
 
 unit-test-shell-generic:
-	@bats --formatter junit --output ${BASH_TEST_REPORT_DIR} ${TESTS_DIR}
+	@bats --report-formatter junit --formatter junit --output ${BASH_TEST_REPORT_DIR} ${TESTS_DIR}
 
 unit-test-shell-generic-no-junit:
-	@bats ${TESTS_DIR}
+	@bats --report-formatter junit ${TESTS_DIR}
 
 .PHONY buildTestImage:
 buildTestImage:

--- a/build/make/bats.mk
+++ b/build/make/bats.mk
@@ -18,15 +18,19 @@ unit-test-shell: unit-test-shell-$(ENVIRONMENT)
 
 $(BATS_ASSERT):
 	@git clone --depth 1 https://github.com/bats-core/bats-assert $@
+	@rm -rf $@/.git
 
 $(BATS_MOCK):
 	@git clone --depth 1 https://github.com/grayhemp/bats-mock $@
+	@rm -rf $@/.git
 
 $(BATS_SUPPORT):
 	@git clone --depth 1 https://github.com/bats-core/bats-support $@
+	@rm -rf $@/.git
 
 $(BATS_FILE):
 	@git clone --depth 1 https://github.com/bats-core/bats-file $@
+	@rm -rf $@/.git
 
 $(BASH_SRC):
 	BASH_SRC:=$(shell find "${WORKDIR}" -type f -name "*.sh")

--- a/build/make/bats/Dockerfile
+++ b/build/make/bats/Dockerfile
@@ -1,7 +1,7 @@
 ARG BATS_BASE_IMAGE
 ARG BATS_TAG
 
-FROM ${BATS_BASE_IMAGE:-bats/bats}:${BATS_TAG:-1.11.0}
+FROM ${BATS_BASE_IMAGE:-bats/bats}:${BATS_TAG:-1.12.0}
 
 # Make bash more findable by scripts and tests
 RUN apk add make git bash

--- a/build/make/bats/customBatsEntrypoint.sh
+++ b/build/make/bats/customBatsEntrypoint.sh
@@ -3,4 +3,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-"$@"
+targetReportDir="${PWD}"/target/shell_test_reports
+uidgid=1000:1000
+exitcode=0
+"$@" || exitcode=$?
+echo "Resetting file ownership to ${uidgid} in ${targetReportDir}/"
+chown -R ${uidgid} "${targetReportDir}"/*
+echo "exiting with code ${exitcode}"
+exit ${exitcode}


### PR DESCRIPTION
This PR
- resolves #235 
- updates BATS from 1.11 to 1.12
- chowns the report files back to non-root